### PR TITLE
update installation instructions

### DIFF
--- a/d4rl/setup.py
+++ b/d4rl/setup.py
@@ -12,8 +12,8 @@ setup(
         "h5py",
         "termcolor",  # adept_envs dependency
         "click",  # adept_envs dependency
-        "dm_control @ git+git://github.com/deepmind/dm_control@master#egg=dm_control",
-        "mjrl @ git+git://github.com/aravindr93/mjrl@master#egg=mjrl",
+        "dm_control @ git+https://github.com/deepmind/dm_control@main#egg=dm_control",
+        "mjrl @ git+https://github.com/aravindr93/mjrl@master#egg=mjrl",
     ],
     packages=find_packages(),
 )


### PR DESCRIPTION
In the latest update urls are now required to use `https` in place of `git`. Furthermore, the branch has now changed from `master` to `main`.